### PR TITLE
🧹 Fix Resource Leak in startTracking and startPositionTracking

### DIFF
--- a/content.js
+++ b/content.js
@@ -4,6 +4,9 @@ let overlayElement = null;
 let lastTrackKey = '';
 let showTimeout = null;
 let hideTimeout = null;
+let trackingInterval = null;
+let initialTrackingTimeout = null;
+let positionInterval = null;
 let isEnabled = true;
 
 // Timing constants (in milliseconds)
@@ -57,8 +60,10 @@ function createOverlay() {
 }
 
 function startPositionTracking() {
+  if (positionInterval) clearInterval(positionInterval);
+
   // Update position every 100ms to track video element
-  setInterval(updateOverlayPosition, 100);
+  positionInterval = setInterval(updateOverlayPosition, 100);
 }
 
 function updateOverlayPosition() {
@@ -124,6 +129,7 @@ function updateOverlayPosition() {
 
 function removeOverlay() {
   clearAllTimeouts();
+  stopAllTracking();
   if (overlayElement) {
     overlayElement.remove();
     overlayElement = null;
@@ -138,6 +144,21 @@ function clearAllTimeouts() {
   if (hideTimeout) {
     clearTimeout(hideTimeout);
     hideTimeout = null;
+  }
+}
+
+function stopAllTracking() {
+  if (trackingInterval) {
+    clearInterval(trackingInterval);
+    trackingInterval = null;
+  }
+  if (initialTrackingTimeout) {
+    clearTimeout(initialTrackingTimeout);
+    initialTrackingTimeout = null;
+  }
+  if (positionInterval) {
+    clearInterval(positionInterval);
+    positionInterval = null;
   }
 }
 
@@ -270,8 +291,11 @@ function scheduleOverlay(trackInfo) {
 }
 
 function startTracking() {
+  if (trackingInterval) clearInterval(trackingInterval);
+  if (initialTrackingTimeout) clearTimeout(initialTrackingTimeout);
+
   // Check for track changes every second
-  setInterval(() => {
+  trackingInterval = setInterval(() => {
     const trackInfo = getCurrentTrackInfo();
     const trackKey = `${trackInfo.artist}|${trackInfo.song}`;
 
@@ -283,7 +307,7 @@ function startTracking() {
   }, 1000);
 
   // Initial check after 2 seconds
-  setTimeout(() => {
+  initialTrackingTimeout = setTimeout(() => {
     const trackInfo = getCurrentTrackInfo();
     if (trackInfo.artist && trackInfo.song) {
       lastTrackKey = `${trackInfo.artist}|${trackInfo.song}`;


### PR DESCRIPTION
This change addresses a resource leak issue in `content.js` where `setInterval` and `setTimeout` IDs were not being stored or cleared correctly. 

Key improvements:
- Resource Management: Interval and timeout IDs for background tracking and overlay positioning are now stored in global variables.
- Idempotency: tracking functions now clear any existing timers before starting new ones, preventing multiple concurrent timers if `init()` is called multiple times.
- Lifecycle Cleanup: A new `stopAllTracking` function handles the cleanup of background timers, and it is called when the overlay is removed or the extension is disabled.
- Bug Prevention: UI visibility timeouts are managed separately from background tracking intervals to ensure that resetting the UI state (e.g., on track change) does not inadvertently stop the tracking logic.

---
*PR created automatically by Jules for task [7594685241136195682](https://jules.google.com/task/7594685241136195682) started by @rophel*