### PR TITLE
🧪 [testing improvement] Add unit tests for popup.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "spotify-mtv-overlay",
+  "version": "1.0.0",
+  "description": "A Chrome browser extension that adds MTV-style artist/album/label overlay text in the bottom left corner while Spotify plays music video playlists on the web player.",
+  "main": "content.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rophel/spotify-mtv-overlay.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "jest": "^29.0.0",
+    "jest-environment-jsdom": "^29.0.0"
+  },
+  "bugs": {
+    "url": "https://github.com/rophel/spotify-mtv-overlay/issues"
+  },
+  "homepage": "https://github.com/rophel/spotify-mtv-overlay#readme"
+}

--- a/popup.js
+++ b/popup.js
@@ -1,8 +1,10 @@
 // Popup Settings Script - V1
 
-document.addEventListener('DOMContentLoaded', function () {
+function initPopup(document, chrome) {
   const enabledCheckbox = document.getElementById('enabled');
   const status = document.getElementById('status');
+
+  if (!enabledCheckbox || !status) return;
 
   // Load saved settings
   chrome.storage.sync.get(['enabled'], function (result) {
@@ -26,4 +28,16 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   enabledCheckbox.addEventListener('change', saveSettings);
-});
+}
+
+// Initialize if in browser environment
+if (typeof document !== 'undefined' && typeof chrome !== 'undefined' && chrome.storage) {
+  document.addEventListener('DOMContentLoaded', () => {
+    initPopup(document, chrome);
+  });
+}
+
+// Export for testing
+if (typeof module !== 'undefined') {
+  module.exports = { initPopup };
+}

--- a/popup.test.js
+++ b/popup.test.js
@@ -1,0 +1,102 @@
+const { initPopup } = require('./popup');
+
+describe('popup.js', () => {
+  let mockDocument;
+  let mockChrome;
+  let mockCheckbox;
+  let mockStatus;
+  let eventListeners;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    eventListeners = {};
+
+    mockCheckbox = {
+      checked: true,
+      addEventListener: jest.fn((event, cb) => {
+        eventListeners[event] = cb;
+      }),
+    };
+
+    mockStatus = {
+      classList: {
+        add: jest.fn(),
+      },
+      style: {
+        display: 'none',
+      },
+    };
+
+    mockDocument = {
+      getElementById: jest.fn((id) => {
+        if (id === 'enabled') return mockCheckbox;
+        if (id === 'status') return mockStatus;
+        return null;
+      }),
+    };
+
+    mockChrome = {
+      storage: {
+        sync: {
+          get: jest.fn((keys, callback) => {
+            callback({ enabled: true });
+          }),
+          set: jest.fn((settings, callback) => {
+            if (callback) callback();
+          }),
+        },
+      },
+    };
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('should load settings on initialization', () => {
+    mockChrome.storage.sync.get.mockImplementation((keys, callback) => {
+      callback({ enabled: false });
+    });
+
+    initPopup(mockDocument, mockChrome);
+
+    expect(mockChrome.storage.sync.get).toHaveBeenCalledWith(['enabled'], expect.any(Function));
+    expect(mockCheckbox.checked).toBe(false);
+  });
+
+  test('should default to enabled if no setting is found', () => {
+    mockChrome.storage.sync.get.mockImplementation((keys, callback) => {
+      callback({});
+    });
+
+    initPopup(mockDocument, mockChrome);
+
+    expect(mockCheckbox.checked).toBe(true);
+  });
+
+  test('should save settings and show status when checkbox changes', () => {
+    initPopup(mockDocument, mockChrome);
+
+    // Simulate checkbox change
+    mockCheckbox.checked = false;
+    eventListeners['change']();
+
+    expect(mockChrome.storage.sync.set).toHaveBeenCalledWith(
+      { enabled: false },
+      expect.any(Function)
+    );
+
+    expect(mockStatus.classList.add).toHaveBeenCalledWith('success');
+    expect(mockStatus.style.display).toBe('block');
+
+    // Fast-forward time to hide status
+    jest.advanceTimersByTime(2000);
+    expect(mockStatus.style.display).toBe('none');
+  });
+
+  test('should not initialize if elements are missing', () => {
+    mockDocument.getElementById.mockReturnValue(null);
+    initPopup(mockDocument, mockChrome);
+    expect(mockChrome.storage.sync.get).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
This PR introduces unit testing for the `popup.js` settings logic. 

**Changes:**
- Refactored `popup.js` to expose an `initPopup` function, enabling testing without a full browser environment.
- Created `popup.test.js` covering:
  - Loading settings from `chrome.storage.sync`.
  - Defaulting to 'enabled' if no setting exists.
  - Saving settings and showing/hiding the status message on change.
  - Graceful handling of missing DOM elements.
- Added `package.json` with Jest configuration.

**Testing:**
- Ran `npm test` and verified all 4 test cases pass.

---
*PR created automatically by Jules for task [5951167704449738786](https://jules.google.com/task/5951167704449738786) started by @rophel*